### PR TITLE
Don't discriminate between in-memory and on-disk buffers.

### DIFF
--- a/src/ngx_http_iconv_module.c
+++ b/src/ngx_http_iconv_module.c
@@ -273,13 +273,6 @@ ngx_http_iconv_merge_chain_link(ngx_http_iconv_ctx_t *ctx, ngx_chain_t *in,
             buf->flush = 1;
         }
 
-        if (cl->buf->in_file) {
-            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-                "iconv does not support in-file bufs");
-
-            return NGX_ERROR;
-        }
-
         if (cl->buf->last_buf) {
             dd("find last buf");
             buf->last_buf = 1;


### PR DESCRIPTION
Environment: nginx 0.8.53 on ubuntu 10.04

Problem: ngx_http_iconv_merge_chain_link() bails out with an error if the buf->in_file flag is set.

Solution: It would seem the in_file check is wrong because the data is in buf->pos regardless of what in_file is set to.

I've tested the patch against both the test suite (all tests pass) and large (>50K) HTML files.
