### PR TITLE
fix wrong struct for malloc

### DIFF
--- a/src/ngx_http_iconv_module.c
+++ b/src/ngx_http_iconv_module.c
@@ -172,7 +172,7 @@ ngx_http_iconv_header_filter(ngx_http_request_t *r)
          *   ctx->uc->len = 0
          *   ctx->uc->data = NULL
          */
-        ctx = ngx_pcalloc(r->pool, sizeof(ngx_http_iconv_module));
+        ctx = ngx_pcalloc(r->pool, sizeof(ngx_http_iconv_ctx_t));
         if (ctx == NULL) {
             return NGX_ERROR;
         }


### PR DESCRIPTION
it should be ngx_http_iconv_ctx_t (though it works fine because ngx_http_iconv_module is larger)